### PR TITLE
Fixed wrong class name used in ErrorEmittongDispatcher docs

### DIFF
--- a/docs/book/dispatcher.md
+++ b/docs/book/dispatcher.md
@@ -63,7 +63,7 @@ $provider->listen(ErrorEvent::class, function (ErrorEvent $event) use ($logger) 
     ]);
 });
 
-$dispatcher = new EventDispatcher($provider);
+$dispatcher = new ErrorEmittingDispatcher($provider);
 
 $dispatcher->dispatch(new SomeEvent());
 ```


### PR DESCRIPTION
This is just a tiny typo fix I have noticed while reading the docs.
