### PR TITLE
Fixed Undefined Variable in PrioritizedListenerProvider

### DIFF
--- a/src/ListenerProvider/PrioritizedListenerProvider.php
+++ b/src/ListenerProvider/PrioritizedListenerProvider.php
@@ -39,7 +39,7 @@ class PrioritizedListenerProvider implements PrioritizedListenerProviderInterfac
     {
         $priority = sprintf('%d.0', $priority);
         if (isset($this->listeners[$priority][$eventType])
-            && in_array($listener, $this->listeners[$priority][$$eventType], true)
+            && in_array($listener, $this->listeners[$priority][$eventType], true)
         ) {
             // Duplicate detected
             return;

--- a/test/ListenerProvider/PrioritizedListenerProviderTest.php
+++ b/test/ListenerProvider/PrioritizedListenerProviderTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace PhlyTest\EventDispatcher;
 
 use Phly\EventDispatcher\ListenerProvider\PrioritizedListenerProvider;
+use PhlyTest\EventDispatcher\TestAsset\TestEvent;
 use PHPUnit\Framework\TestCase;
 use SplObserver;
 
@@ -54,5 +55,22 @@ class PrioritizedListenerProviderTest extends TestCase
             $listener3,
             $listener2,
         ], $listeners);
+    }
+
+    public function testNoDuplicateListenersAreProvided()
+    {
+        $event = new TestAsset\TestEvent();
+
+        $listener = $this->createListener();
+
+        $this->listeners->listen(TestEvent::class, $listener, 1);
+        $this->listeners->listen(TestEvent::class, $listener, 1);
+
+        $listeners = [];
+        foreach ($this->listeners->getListenersForEvent($event) as $listener) {
+            $listeners[] = $listener;
+        }
+
+        $this->assertCount(1, $listeners);
     }
 }


### PR DESCRIPTION
This PR fixes an undefined variable error when attaching multiple listeners with the same event type and priority on the `Phly\EventDispatcher\ListenerProvider\PrioritizedListenerProvider::listen()` method.
