### PR TITLE
Allow ListenerProviderAggregate to be instantiated with providers

### DIFF
--- a/src/ListenerProvider/ListenerProviderAggregate.php
+++ b/src/ListenerProvider/ListenerProviderAggregate.php
@@ -18,6 +18,11 @@ class ListenerProviderAggregate implements ListenerProviderInterface
      */
     private $providers = [];
 
+    public function __construct(ListenerProviderInterface ...$providers)
+    {
+        $this->providers = $providers;
+    }
+
     public function getListenersForEvent(object $event) : iterable
     {
         foreach ($this->providers as $provider) {


### PR DESCRIPTION
:wave: This PR allows a varidic to be provided to the constructor of the Aggregate listener provider.

So in addition to:
```
        $aggregate = new ListenerProviderAggregate();
        $aggregate->attach(new ServiceListener($serviceManager));
        $aggregate->attach(new WorkspaceListener($workspace));

        $eventDispatcher = new EventDispatcher($aggregate);

```
we can:

```
        $eventDispatcher = new EventDispatcher(
            new ListenerProviderAggregate(
                new ServiceListener($serviceManager),
                new WorkspaceListener($workspace)
            )
        );
```
