### PR TITLE
Provide PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "rss": "https://github.com/phly/phly-event-dispatcher/releases.atom"
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "psr/container": "^1.0",
         "psr/event-dispatcher": "^1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01cfd39ecd592b818b588352750bb728",
+    "content-hash": "6749774fae8a66a2f0a0f7134c7c8a40",
     "packages": [
         {
             "name": "psr/container",
@@ -2430,7 +2430,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
+    convertDeprecationsToExceptions="true"
     colors="true">
     <coverage processUncoveredFiles="true">
         <include>


### PR DESCRIPTION
- Add `~8.1.0` to the list of php constraints
- Enable deprecations -> exceptions in phpunit to ensure we are not hitting any deprecations
